### PR TITLE
Add coordination context

### DIFF
--- a/constructr-cassandra/src/main/scala/de/heikoseeberger/constructr/cassandra/Constructr.scala
+++ b/constructr-cassandra/src/main/scala/de/heikoseeberger/constructr/cassandra/Constructr.scala
@@ -33,7 +33,7 @@ object Constructr {
 
   def props(strategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy): Props = Props(new Constructr(strategy))
 
-  private def intoJoiningHandler(constructr: ActorRef)(machine: ConstructrMachine[InetAddress]): ConstructrMachine.TransitionHandler[InetAddress] = {
+  private def intoJoiningHandler[B <: Coordination.Backend](constructr: ActorRef)(machine: ConstructrMachine[InetAddress, B]): ConstructrMachine.TransitionHandler[InetAddress] = {
     case (_, ConstructrMachine.State.Joining) => constructr ! Constructr.Nodes(machine.nextStateData.nodes)
   }
 }


### PR DESCRIPTION
@juanjovazquez, please check out this PR/branch, which brings back the `Refreshing` state as well as dependently typed values for `AddedSelf` and `Refreshed`.