### PR TITLE
Redis backed Coordination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ services:
 
 before_install:
 - docker pull quay.io/coreos/etcd:v2.3.1
+- docker pull redis:3
 - docker run --detach --publish 2379:2379 quay.io/coreos/etcd:v2.3.1 --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://127.0.0.1:2379
+- docker run --detach --publish 6379:6379 -d redis:3
 
 script: sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,11 @@ lazy val constructrCoordinationEtcd = project
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(constructrCoordination)
 
+lazy val constructrCoordinationRedis = project
+  .copy(id = "constructr-coordination-redis")
+  .in(file("constructr-coordination-redis"))
+  .dependsOn(constructrCoordination)
+
 lazy val constructrMachine = project
   .copy(id = "constructr-machine")
   .in(file("constructr-machine"))
@@ -26,7 +31,7 @@ lazy val constructrAkka = project
   .in(file("constructr-akka"))
   .enablePlugins(AutomateHeaderPlugin)
   .configs(MultiJvm)
-  .dependsOn(constructrMachine, constructrCoordinationEtcd % "test->compile")
+  .dependsOn(constructrMachine, constructrCoordinationRedis % "test->compile")
 
 lazy val constructrCassandra = project
   .copy(id = "constructr-cassandra")

--- a/constructr-coordination-redis/build.sbt
+++ b/constructr-coordination-redis/build.sbt
@@ -1,0 +1,8 @@
+name := "constructr-coordination-redis"
+
+libraryDependencies ++= Vector(
+  Library.rediscala,
+  Library.raptureJsonCirce,
+  Library.akkaTestkit % "test",
+  Library.scalaTest   % "test"
+)

--- a/constructr-coordination-redis/src/main/resources/LICENSE.txt
+++ b/constructr-coordination-redis/src/main/resources/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/constructr-coordination-redis/src/main/resources/reference.conf
+++ b/constructr-coordination-redis/src/main/resources/reference.conf
@@ -1,0 +1,11 @@
+constructr {
+  coordination {
+    class-name = de.heikoseeberger.constructr.coordination.redis.RedisCoordination
+    host       = localhost
+    port       = 6379
+    redis {
+      # password   =
+      # db         =
+    }
+  }
+}

--- a/constructr-coordination-redis/src/main/scala/de/heikoseeberger/constructr/coordination/redis/RedisCoordination.scala
+++ b/constructr-coordination-redis/src/main/scala/de/heikoseeberger/constructr/coordination/redis/RedisCoordination.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 Shingo Omura
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.constructr.coordination
+package redis
+
+import java.util.Base64
+
+import _root_.redis.RedisClient
+import akka.Done
+import akka.actor.{ ActorRefFactory, ActorSystem }
+import com.typesafe.config.{ Config, ConfigException }
+import de.heikoseeberger.constructr.coordination.Coordination.NodeSerialization
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+final class RedisCoordination(
+    val prefix: String,
+    val clusterName: String,
+    val system: ActorSystem
+) extends Coordination {
+  implicit val _system: ActorRefFactory = system
+  implicit val _ec = _system.dispatcher
+
+  val redis = RedisClientFactory.fromConfig(system.settings.config)
+
+  def lockKey = s"${prefix}/${clusterName}/lock"
+  def nodeKeyPrefix = s"${prefix}/${clusterName}/nodes"
+  def nodeKey[A: NodeSerialization](self: A) = s"${nodeKeyPrefix}/${Base64.getUrlEncoder.encodeToString(NodeSerialization.toBytes(self))}"
+
+  /**
+   * Get the nodes.
+   *
+   * @tparam A node type, must have a [[Coordination.NodeSerialization]]
+   * @return future of nodes
+   */
+  override def getNodes[A: NodeSerialization](): Future[Set[A]] = redis.keys(s"${nodeKeyPrefix}/*").map(ks => scala.collection.immutable.Seq(ks: _*)).flatMap { ks =>
+    // N+1 problem would happen here.
+    // But N might not be so large in real situation.
+    val f: Seq[Future[Option[A]]] = for {
+      k <- ks
+    } yield {
+      for {
+        bytesOpt <- redis.get[Array[Byte]](k)
+      } yield {
+        bytesOpt.map(NodeSerialization.fromBytes[A])
+      }
+    }
+    Future.sequence(f).map { opts =>
+      opts.filter(_.nonEmpty)
+    }.map { somes =>
+      somes.map(_.get)
+    }.map {
+      _.toSet
+    }
+  }
+
+  /**
+   * Akquire a lock for bootstrapping the cluster (first node).
+   *
+   * @param self self node
+   * @param ttl  TTL for the lock
+   * @tparam A node type, must have a [[Coordination.NodeSerialization]]
+   * @return true, if lock could be akquired, else false
+   */
+  override def lock[A: NodeSerialization](self: A, ttl: FiniteDuration): Future[Boolean] = {
+    def readLock(): Future[Option[A]] = redis.get[Array[Byte]](lockKey).map(_.map(NodeSerialization.fromBytes[A]))
+    def writeLock(lockHolder: A): Future[Boolean] = {
+      val trans2 = redis.watch(lockKey)
+      val writeLock = trans2.set(lockKey, NodeSerialization.toBytes(lockHolder), None, Some(ttl.toMillis))
+      trans2.exec()
+      writeLock.recover {
+        case error => false
+      }
+    }
+    readLock().flatMap {
+      case Some(lockHolder) if lockHolder != self => Future.successful(false)
+      case _                                      => writeLock(self)
+    }
+  }
+
+  /**
+   * Refresh entry for self.
+   *
+   * @param self self node
+   * @param ttl  TTL for the node entry
+   * @tparam A node type, must have a [[Coordination.NodeSerialization]]
+   * @return future signaling done
+   */
+  override def refresh[A: NodeSerialization](self: A, ttl: FiniteDuration): Future[Done] = addSelfOrRefresh(self, ttl)
+
+  /**
+   * Add self to the nodes.
+   *
+   * @param self self node
+   * @param ttl  TTL for the node entry
+   * @tparam A node type, must have a [[Coordination.NodeSerialization]]
+   * @return future signaling done
+   */
+  override def addSelf[A: NodeSerialization](self: A, ttl: FiniteDuration): Future[Done] = addSelfOrRefresh(self, ttl)
+
+  // redis doesn't support element-wise ttl in [sorted] sets.
+  // So, this sets with
+  //   key -> {prefix}/{clusterName}/nodes/{encoded self}
+  //   value -> encoded self
+  private def addSelfOrRefresh[A: NodeSerialization](self: A, ttl: FiniteDuration): Future[Done] = redis.set(nodeKey(self), NodeSerialization.toBytes(self), None, Some(ttl.toMillis)).map(_ => Done)
+
+}
+
+object RedisClientFactory {
+  def fromConfig(config: Config)(implicit af: ActorRefFactory): RedisClient = {
+    val host = Option(config.getString("constructr.coordination.host")).filter(_.trim.nonEmpty).getOrElse("")
+    val port = config.getInt("constructr.coordination.port")
+    require(host.nonEmpty, "\"constructr.coordination.redis.host\" must be given.")
+    require(port > 0, "\"constructr.coordination.redis.port\" must be positive integer.")
+
+    val password = try {
+      Option(config.getString("constructr.coordination.redis.password")).filter(_.nonEmpty)
+    } catch {
+      case e: ConfigException.Missing => None
+    }
+    val db = try {
+      Option(config.getInt("constructr.coordination.redis.db"))
+    } catch {
+      case e: ConfigException.Missing => None
+    }
+
+    RedisClient(host, port, password, db)
+  }
+
+}

--- a/constructr-coordination-redis/src/test/scala/de/heikoseeberger/constructr/coordination/redis/RedisCoordinationSpec.scala
+++ b/constructr-coordination-redis/src/test/scala/de/heikoseeberger/constructr/coordination/redis/RedisCoordinationSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Shingo Omura
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.heikoseeberger.constructr.coordination.redis
+
+import java.nio.charset.StandardCharsets._
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import de.heikoseeberger.constructr.coordination.Coordination
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+import scala.concurrent.{ Awaitable, Await }
+import scala.concurrent.duration._
+import scala.util.Random
+
+object RedisCoordinationSpec {
+  import Coordination._
+
+  private implicit val stringNodeSerialization = new NodeSerialization[String] {
+    override def fromBytes(bytes: Array[Byte]) = new String(bytes, UTF_8)
+    override def toBytes(s: String) = s.getBytes(UTF_8)
+  }
+
+  // this test assumes redis server is up on DOCKER_HOST or localhost(127.0.0.1)
+  // below command would be help:
+  //   $ docker run --name some-redis -p 6379:6379 -d redis
+  private val coordinationHost = {
+    val dockerHostPattern = """tcp://(\S+):\d{1,5}""".r
+    sys.env.get("DOCKER_HOST")
+      .collect { case dockerHostPattern(address) => address }
+      .getOrElse("127.0.0.1")
+  }
+}
+
+class RedisCoordinationSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+  import RedisCoordinationSpec._
+
+  private implicit val system = {
+    val config = ConfigFactory.parseString(s"constructr.coordination.host = $coordinationHost").withFallback(ConfigFactory.load())
+    ActorSystem("default", config)
+  }
+
+  "RedisCoordination" should {
+    "correctly interact with redis" in {
+      val coordination: Coordination = new RedisCoordination(randomString(), randomString(), system)
+
+      resultOf(coordination.getNodes[String]()) shouldBe 'empty
+
+      resultOf(coordination.lock[String]("self", 10.seconds)) shouldBe true
+      resultOf(coordination.lock[String]("self", 10.seconds)) shouldBe true
+      resultOf(coordination.lock[String]("other", 10.seconds)) shouldBe false
+
+      resultOf(coordination.addSelf[String]("self", 10.seconds)) shouldBe Done
+      resultOf(coordination.getNodes[String]()) shouldBe Set("self")
+
+      resultOf(coordination.refresh[String]("self", 1.second)) shouldBe Done
+      resultOf(coordination.getNodes[String]()) shouldBe Set("self")
+
+      val probe = TestProbe()
+      import probe._
+      within(5.seconds) { // 2 seconds should be enough, but who knows hows ...
+        awaitAssert {
+          resultOf(coordination.getNodes[String]()) shouldBe 'empty
+        }
+      }
+    }
+  }
+
+  override protected def afterAll() = {
+    Await.ready(system.terminate(), Duration.Inf)
+    super.afterAll()
+  }
+
+  private def resultOf[A](awaitable: Awaitable[A], max: FiniteDuration = 3.seconds): A = Await.result(awaitable, max)
+
+  private def randomString() = math.abs(Random.nextInt).toString
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,6 +29,11 @@ object Build extends AutoPlugin {
                     <name>Heiko Seeberger</name>
                     <url>http://heikoseeberger.de</url>
                   </developer>
+                  <developer>
+                    <id>everpeace</id>
+                    <name>Shingo Omura</name>
+                    <url>https://everpeace.github.io</url>
+                  </developer>
                 </developers>,
     scalaVersion := Version.Scala,
     crossScalaVersions := Vector(scalaVersion.value),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Version {
   final val Cassandra        = "3.3"
   final val Log4j            = "2.5"
   final val RaptureJsonSpray = "2.0.0-M5"
+  final val Rediscala        = "1.6.0"
   final val Scala            = "2.11.8"
   final val ScalaMock        = "3.2.2"
   final val ScalaTest        = "2.2.6"
@@ -22,6 +23,7 @@ object Library {
   val cassandraAll         = "org.apache.cassandra"     %  "cassandra-all"               % Version.Cassandra exclude("commons-logging", "commons-logging")
   val log4jCore            = "org.apache.logging.log4j" %  "log4j-core"                  % Version.Log4j
   val raptureJsonCirce     = "com.propensive"           %% "rapture-json-circe"          % Version.RaptureJsonSpray
+  val rediscala            = "com.github.etaty"         %% "rediscala"                   % Version.Rediscala
   val scalaMock            = "org.scalamock"            %% "scalamock-scalatest-support" % Version.ScalaMock
   val scalaTest            = "org.scalatest"            %% "scalatest"                   % Version.ScalaTest
 }


### PR DESCRIPTION
Hi!  Thank you for sharing great project!

I added new Redis backed coordination implementation.

I'm really happy if you would review and give me some feedbacks.

if you prefer to make this open in other repository like consul coordination implementation, I don't mind it and please feel free to ask so.

Thanks!

## Design Overview
* [rediscala](https://github.com/etaty/rediscala) is applied as a redis client library  because the client supports non-blocking client based on akka io.
  * Although this client library supports connection pooling, this feature is not used because access frequency to redis server is not so high in constructr in real situation.
* seed nodes will be stored into separated keys like etcd coordination.  (with keys `$prefix/$clusterName/nodes/$encodedSelf`)
  * this strategy causes N+1 problem when extracting seed nodes
  * however I suppose that N might not be huge in real situation and moreover extraction of seed nodes will be executed only once, it is when some node starts up (tries to join to the cluster).
  * So, I believe this N+1 invocations will not cause serial performance issue.
* lock node(initial node of the cluster) will be stored in intuitive way (with key `$prefix/$clusterName/lock`)

## How to test
I wrote integration test(`RedisCoordinationSpec`).  This test assumes Redis server is up on `DOCKER_HOST` or localhost as well as etcd coordination's test.  This command would be help to execute test

```
$ docker run --name some-redis -p 6379:6379 -d redis
$ sbt "project constructr-coordination-redis" "test"
```