### PR TITLE
Catch unhandled events

### DIFF
--- a/constructr/src/main/scala/de/heikoseeberger/constructr/ConstructrMachine.scala
+++ b/constructr/src/main/scala/de/heikoseeberger/constructr/ConstructrMachine.scala
@@ -188,14 +188,8 @@ final class ConstructrMachine(
     case Event(MemberJoined(member), _) if member.address == selfNode =>
       goto(State.AddingSelf)
 
-    case Event(MemberJoined(member), _) =>
-      stay()
-
     case Event(MemberUp(member), _) if member.address == selfNode =>
       goto(State.AddingSelf)
-
-    case Event(MemberUp(member), _) =>
-      stay()
 
     case Event(StateTimeout, _) =>
       stop(Failure("Timeout in Joining!"))
@@ -284,6 +278,12 @@ final class ConstructrMachine(
     case Event(StateTimeout, Data(_, retryState, _)) =>
       log.debug(s"Waited for $retryDelay, going to $retryState")
       goto(retryState)
+  }
+
+  // Unhandled events
+
+  whenUnhandled {
+    case _: Event => stay()
   }
 
   // Initialization


### PR DESCRIPTION
Adding an `whenUnhandled` function to the `ConstructrMachine` to catch unhandled FSM events. When an unhandled event is received the FSM state is kept and nothing else is done. With that in place no "unhandled event" warnings are written to the log anymore.

Fixes #121.

Tested with ConductR as an Akka cluster.
