### PR TITLE
Update constructr version in README to 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If something goes finally wrong when interacting with the coordination service, 
 resolvers += Resolver.bintrayRepo("hseeberger", "maven")
 
 libraryDependencies ++= Vector(
-  "de.heikoseeberger" %% "constructr" % "0.16.0",
+  "de.heikoseeberger" %% "constructr" % "0.16.1",
   "de.heikoseeberger" %% "constructr-coordination-etcd" % "0.16.1", // in case of using etcd for coordination
   ...
 )


### PR DESCRIPTION
The `"de.heikoseeberger" %% "constructr”` version in README was `0.16.0` but the current version is `0.16.1`.

This PR is updating the README accordingly.