### PR TITLE
Multiple ActorSystems and ClusterActorRefProvider setting causes akka-remoting to be started twice

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,5 +1,3 @@
-akka.actor.provider = akka.cluster.ClusterActorRefProvider
-
 constructr {
   coordination-timeout = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
   join-timeout         = 15 seconds // Might depend on cluster size and network properties


### PR DESCRIPTION
In the case where a single application launches multiple ActorSystem instances (e.g. with Kamon this is unavoidable) the  `akka.actor.provider = ClusterActorRefProvider` setting causes both actor systems to attempt the initialization of akka remoting. Only one attempt will succeed in the case both bind on the same port (the default). 

This change will most probably break any existing usages where the application configuration is piggybacking on the `akka.actor.provider` configuration provided here.