### PR TITLE
Multiple ActorSystems and ClusterActorRefProvider cause duplicate init of akka-remoting (closes #151)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,5 +1,3 @@
-akka.actor.provider = akka.cluster.ClusterActorRefProvider
-
 constructr {
   coordination-timeout = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
   join-timeout         = 15 seconds // Might depend on cluster size and network properties

--- a/core/src/multi-jvm/resources/application.conf
+++ b/core/src/multi-jvm/resources/application.conf
@@ -1,0 +1,1 @@
+akka.actor.provider = akka.cluster.ClusterActorRefProvider

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+akka.actor.provider = akka.cluster.ClusterActorRefProvider


### PR DESCRIPTION
This change will most probably break any existing usages where the application configuration is piggybacking on the `akka.actor.provider` configuration provided here.