### PR TITLE
Unlimited number of retries in Refreshing (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ constructr {
     port = 2379
   }
 
-  coordination-timeout = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
-  join-timeout         = 15 seconds // Might depend on cluster size and network properties
-  max-nr-of-seed-nodes = 0          // Any nonpositive value means Int.MaxValue
-  nr-of-retries        = 2          // Nr. of tries are nr. of retries + 1
-  refresh-interval     = 30 seconds // TTL is refresh-interval * ttl-factor
-  retry-delay          = 3 seconds  // Give coordination service (e.g. etcd) some delay before retrying
-  ttl-factor           = 2.0        // Must be greater or equal 1 + ((coordination-timeout * (1 + nr-of-retries) + retry-delay * nr-of-retries)/ refresh-interval)!
+  coordination-timeout    = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
+  join-timeout            = 15 seconds // Might depend on cluster size and network properties
+  max-nr-of-seed-nodes    = 0          // Any nonpositive value means Int.MaxValue
+  nr-of-retries           = 2          // Nr. of tries are nr. of retries + 1
+  refresh-interval        = 30 seconds // TTL is refresh-interval * ttl-factor
+  retry-delay             = 3 seconds  // Give coordination service (e.g. etcd) some delay before retrying
+  ttl-factor              = 2.0        // Must be greater or equal 1 + ((coordination-timeout * (1 + nr-of-retries) + retry-delay * nr-of-retries)/ refresh-interval)!
+  ignore-refresh-failures = false      // Ignore failures once machine is already in "Refreshing" state. It prevents from FSM being terminated due to exhausted number of retries.
+
 }
 ```
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,9 +1,10 @@
 constructr {
-  coordination-timeout = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
-  join-timeout         = 15 seconds // Might depend on cluster size and network properties
-  max-nr-of-seed-nodes = 0          // Any nonpositive value means Int.MaxValue
-  nr-of-retries        = 2          // Nr. of tries are nr. of retries + 1
-  refresh-interval     = 30 seconds // TTL is refresh-interval * ttl-factor
-  retry-delay          = 3 seconds  // Give coordination service (e.g. etcd) some delay before retrying
-  ttl-factor           = 2.0        // Must be greater or equal 1 + ((coordination-timeout * (1 + nr-of-retries) + retry-delay * nr-of-retries)/ refresh-interval)!
+  coordination-timeout    = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
+  join-timeout            = 15 seconds // Might depend on cluster size and network properties
+  max-nr-of-seed-nodes    = 0          // Any nonpositive value means Int.MaxValue
+  nr-of-retries           = 2          // Nr. of tries are nr. of retries + 1
+  refresh-interval        = 30 seconds // TTL is refresh-interval * ttl-factor
+  retry-delay             = 3 seconds  // Give coordination service (e.g. etcd) some delay before retrying
+  ttl-factor              = 2.0        // Must be greater or equal 1 + ((coordination-timeout * (1 + nr-of-retries) + retry-delay * nr-of-retries)/ refresh-interval)!
+  ignore-refresh-failures = false      // Ignore failures once machine is already in "Refreshing" state. It prevents from FSM being terminated due to exhausted number of retries.
 }

--- a/core/src/main/scala/de/heikoseeberger/constructr/Constructr.scala
+++ b/core/src/main/scala/de/heikoseeberger/constructr/Constructr.scala
@@ -75,13 +75,14 @@ final class Constructr private extends Actor with ActorLogging {
     def getDuration(key: String) =
       FiniteDuration(config.getDuration(key).toNanos, NANOSECONDS)
 
-    val coordinationTimeout = getDuration("constructr.coordination-timeout")
-    val nrOfRetries         = config.getInt("constructr.nr-of-retries")
-    val retryDelay          = getDuration("constructr.retry-delay")
-    val refreshInterval     = getDuration("constructr.refresh-interval")
-    val ttlFactor           = config.getDouble("constructr.ttl-factor")
-    val maxNrOfSeedNodes    = config.getInt("constructr.max-nr-of-seed-nodes")
-    val joinTimeout         = getDuration("constructr.join-timeout")
+    val coordinationTimeout   = getDuration("constructr.coordination-timeout")
+    val nrOfRetries           = config.getInt("constructr.nr-of-retries")
+    val retryDelay            = getDuration("constructr.retry-delay")
+    val refreshInterval       = getDuration("constructr.refresh-interval")
+    val ttlFactor             = config.getDouble("constructr.ttl-factor")
+    val maxNrOfSeedNodes      = config.getInt("constructr.max-nr-of-seed-nodes")
+    val joinTimeout           = getDuration("constructr.join-timeout")
+    val ignoreRefreshFailures = config.getBoolean("constructr.ignore-refresh-failures")
 
     context.actorOf(
       ConstructrMachine.props(
@@ -93,7 +94,8 @@ final class Constructr private extends Actor with ActorLogging {
         refreshInterval,
         ttlFactor,
         if (maxNrOfSeedNodes <= 0) Int.MaxValue else maxNrOfSeedNodes,
-        joinTimeout
+        joinTimeout,
+        ignoreRefreshFailures
       ),
       ConstructrMachine.Name
     )

--- a/core/src/test/scala/de/heikoseeberger/constructr/ConstructrMachineSpec.scala
+++ b/core/src/test/scala/de/heikoseeberger/constructr/ConstructrMachineSpec.scala
@@ -225,11 +225,11 @@ final class ConstructrMachineSpec extends WordSpec with Matchers with BeforeAndA
         delayed(1.hour.dilated, system.scheduler)(boom()),
         boom(),
         boom(),
-        Future.successful(Done),
+        Future.successful(Done)
       )
 
       val nrOfRetries = 2
-      val monitor = TestProbe()
+      val monitor     = TestProbe()
       val machine = system.actorOf(
         Props(
           new ConstructrMachine(


### PR DESCRIPTION
The idea is to have ability to prevent FSM from being stopped due to exhausted number of retries in Refreshing state. So otherwise fully functional cluster won't get terminated due to communication issues with coordination service.