### PR TITLE
Add `close()` method to `Coordination` for resource cleanup

### DIFF
--- a/coordination-etcd/src/main/scala/de/heikoseeberger/constructr/coordination/etcd/EtcdCoordination.scala
+++ b/coordination-etcd/src/main/scala/de/heikoseeberger/constructr/coordination/etcd/EtcdCoordination.scala
@@ -162,6 +162,9 @@ final class EtcdCoordination(clusterName: String, system: ActorSystem) extends C
   override def refresh(self: Address, ttl: FiniteDuration) =
     addSelfOrRefresh(self, ttl)
 
+  override def close(): Future[Done] =
+    Future.successful(Done)
+
   private def addSelfOrRefresh(self: Address, ttl: FiniteDuration) = {
     val node  = getUrlEncoder.encodeToString(self.toString.getBytes(UTF_8))
     val query = Uri.Query("ttl" -> toSeconds(ttl), "value" -> self.toString)

--- a/coordination/src/main/scala/de/heikoseeberger/constructr/coordination/Coordination.scala
+++ b/coordination/src/main/scala/de/heikoseeberger/constructr/coordination/Coordination.scala
@@ -55,11 +55,11 @@ trait Coordination {
   def getNodes(): Future[Set[Address]]
 
   /**
-    * Akquire a lock for bootstrapping the cluster (first node).
+    * Acquire a lock for bootstrapping the cluster (first node).
     *
     * @param self self node
     * @param ttl TTL for the lock
-    * @return true, if lock could be akquired, else false
+    * @return true, if lock could be acquired, else false
     */
   def lock(self: Address, ttl: FiniteDuration): Future[Boolean]
 
@@ -80,4 +80,11 @@ trait Coordination {
     * @return future signaling done
     */
   def refresh(self: Address, ttl: FiniteDuration): Future[Done]
+
+  /**
+    * Performs resource cleanup on termination
+    *
+    * @return future signaling done
+    */
+  def close(): Future[Done]
 }


### PR DESCRIPTION
Closes #167.