### PR TITLE
Propagate extension failures to user-space (refs #171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ member-joined │
     └───────────────────┘              └───────────────────┘
 ```
 
-If something goes finally wrong when interacting with the coordination service, e.g. a permanent timeout after a configurable number of retries, ConstructR terminates its `ActorSystem` in the spirit of "fail fast".
+If something goes finally wrong when interacting with the coordination service, e.g. a permanent timeout after a configurable number of retries, ConstructR terminates itself in the spirit of "failing fast".
 
 ``` scala
 // All releases including intermediate ones are published here,
@@ -76,6 +76,14 @@ constructr {
 
 }
 ```
+
+Exceeding the number of max retries will lead to internal failure of the `ConstructrExtension`. You can hook to this event in the following manner:
+``` scala
+val constructr = ConstructrExtension(system)
+constructr.registerOnFailure {
+    // do something if ConstructR failes
+}
+``` 
 
 ## Coordination
 


### PR DESCRIPTION
As discussed in #171 I have removed the actor-system stopping behavior, modernized the `ConstructrExtension` by switching to the new style of extension implementation and added the ability to hook up event handlers to ConstructR failures, for which I added a couple of tests as well. In the context of this work I also removed the deprecated `ActorDSL` stuff from the multi-jvm test and replaced it with regular actor creation code, as per akka guidelines.