### PR TITLE
Restart FSM process on seed node failures (fixes #168)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 constructr {
   coordination-timeout    = 3 seconds  // Maximum response time for coordination service (e.g. etcd)
   join-timeout            = 15 seconds // Might depend on cluster size and network properties
+  abort-on-join-timeout   = false      // Abort the attempt to join if true; otherwise restart the process from scratch
   max-nr-of-seed-nodes    = 0          // Any nonpositive value means Int.MaxValue
   nr-of-retries           = 2          // Nr. of tries are nr. of retries + 1
   refresh-interval        = 30 seconds // TTL is refresh-interval * ttl-factor

--- a/core/src/main/scala/de/heikoseeberger/constructr/Constructr.scala
+++ b/core/src/main/scala/de/heikoseeberger/constructr/Constructr.scala
@@ -82,6 +82,7 @@ final class Constructr private extends Actor with ActorLogging {
     val ttlFactor             = config.getDouble("constructr.ttl-factor")
     val maxNrOfSeedNodes      = config.getInt("constructr.max-nr-of-seed-nodes")
     val joinTimeout           = getDuration("constructr.join-timeout")
+    val abortOnJoinTimeout    = config.getBoolean("constructr.abort-on-join-timeout")
     val ignoreRefreshFailures = config.getBoolean("constructr.ignore-refresh-failures")
 
     context.actorOf(
@@ -95,6 +96,7 @@ final class Constructr private extends Actor with ActorLogging {
         ttlFactor,
         if (maxNrOfSeedNodes <= 0) Int.MaxValue else maxNrOfSeedNodes,
         joinTimeout,
+        abortOnJoinTimeout,
         ignoreRefreshFailures
       ),
       ConstructrMachine.Name

--- a/core/src/main/scala/de/heikoseeberger/constructr/ConstructrMachine.scala
+++ b/core/src/main/scala/de/heikoseeberger/constructr/ConstructrMachine.scala
@@ -17,13 +17,13 @@
 package de.heikoseeberger.constructr
 
 import akka.Done
-import akka.actor.FSM.Failure
 import akka.actor.{ Address, FSM, Props, Status }
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.{ InitialStateAsEvents, MemberJoined, MemberUp }
 import akka.pattern.pipe
 import akka.stream.ActorMaterializer
 import de.heikoseeberger.constructr.coordination.Coordination
+
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 object ConstructrMachine {
@@ -39,13 +39,14 @@ object ConstructrMachine {
 
   sealed trait State
   final object State {
-    case object GettingNodes     extends State
-    case object Locking          extends State
-    case object Joining          extends State
-    case object AddingSelf       extends State
-    case object RefreshScheduled extends State
-    case object Refreshing       extends State
-    case object RetryScheduled   extends State
+    case object BeforeGettingNodes extends State
+    case object GettingNodes       extends State
+    case object Locking            extends State
+    case object Joining            extends State
+    case object AddingSelf         extends State
+    case object RefreshScheduled   extends State
+    case object Refreshing         extends State
+    case object RetryScheduled     extends State
   }
 
   final case class Data(nodes: Set[Address], retryState: State, nrOfRetriesLeft: Int)
@@ -65,6 +66,7 @@ object ConstructrMachine {
       ttlFactor: Double,
       maxNrOfSeedNodes: Int,
       joinTimeout: FiniteDuration,
+      abortOnJoinTimeout: Boolean,
       ignoreRefreshFailures: Boolean
   ): Props =
     Props(
@@ -78,6 +80,7 @@ object ConstructrMachine {
         ttlFactor,
         maxNrOfSeedNodes,
         joinTimeout,
+        abortOnJoinTimeout,
         ignoreRefreshFailures
       )
     )
@@ -93,6 +96,7 @@ final class ConstructrMachine(
     ttlFactor: Double,
     maxNrOfSeedNodes: Int,
     joinTimeout: FiniteDuration,
+    abortOnJoinTimeout: Boolean,
     ignoreRefreshFailures: Boolean
 ) extends FSM[ConstructrMachine.State, ConstructrMachine.Data] {
   import ConstructrMachine._
@@ -109,6 +113,13 @@ final class ConstructrMachine(
   private val cluster      = Cluster(context.system)
 
   startWith(State.GettingNodes, Data(Set.empty, State.GettingNodes, nrOfRetries))
+
+  // Before getting nodes
+
+  when(State.BeforeGettingNodes, retryDelay) {
+    case Event(StateTimeout, _) =>
+      goto(State.GettingNodes).using(Data(Set.empty, State.GettingNodes, nrOfRetries))
+  }
 
   // Getting nodes
 
@@ -163,8 +174,7 @@ final class ConstructrMachine(
 
     case Event(false, _) =>
       log.warning("Couldn't acquire lock, going to GettingNodes")
-      goto(State.GettingNodes)
-        .using(stateData.copy(nrOfRetriesLeft = nrOfRetries))
+      goto(State.BeforeGettingNodes)
 
     case Event(Status.Failure(cause), _) =>
       log.warning(s"Failure in $stateName, going to Locking: $cause")
@@ -196,7 +206,10 @@ final class ConstructrMachine(
       goto(State.AddingSelf)
 
     case Event(StateTimeout, _) =>
-      stop(Failure("Timeout in Joining!"))
+      if (abortOnJoinTimeout)
+        stop(FSM.Failure("Timeout in Joining!"))
+      else
+        goto(State.GettingNodes).using(Data(Set.empty, State.GettingNodes, nrOfRetries))
   }
 
   onTransition {
@@ -287,6 +300,10 @@ final class ConstructrMachine(
   // Unhandled events
 
   whenUnhandled {
+    case Event(MemberJoined(member), _) if member.address == selfNode && isPreJoining =>
+      goto(State.AddingSelf).using(stateData.copy(nrOfRetriesLeft = nrOfRetries))
+    case Event(MemberUp(member), _) if member.address == selfNode && isPreJoining =>
+      goto(State.AddingSelf).using(stateData.copy(nrOfRetriesLeft = nrOfRetries))
     // Unsubscribe might be late
     case Event(MemberJoined(_) | MemberUp(_), _) => stay()
   }
@@ -319,4 +336,10 @@ final class ConstructrMachine(
       )
     else
       retry(State.Refreshing)
+
+  private def isPreJoining: Boolean =
+    stateName match {
+      case State.BeforeGettingNodes | State.GettingNodes | State.Locking => true
+      case _                                                             => false
+    }
 }

--- a/core/src/test/scala/de/heikoseeberger/constructr/ConstructrExtensionSpec.scala
+++ b/core/src/test/scala/de/heikoseeberger/constructr/ConstructrExtensionSpec.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.constructr
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.cluster.{ Cluster, MemberStatus }
+import com.typesafe.config.ConfigFactory
+import de.heikoseeberger.constructr.testutil.CoordinationInfo
+import org.scalatest.concurrent.Eventually
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.time._
+import org.scalatest.{ BeforeAndAfterEach, Matchers, WordSpec }
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
+
+class ConstructrExtensionSpec
+    extends WordSpec
+    with Matchers
+    with MockitoSugar
+    with BeforeAndAfterEach
+    with Eventually {
+
+  import ConstructrExtensionSpec._
+
+  private[this] var clusterNodes = Seq.empty[ActorSystem]
+
+  override protected def afterEach(): Unit =
+    dispose(clusterNodes)
+
+  "Cluster members managed by ConstructR" should {
+    // Happy path
+    "successfully join the cluster under normal circumstances" in {
+      val clusterName = generateClusterName()
+      clusterNodes = 0.until(5).map(i => createClusterNode(clusterName, 15000 + i))
+      eventuallyUp(clusterNodes, 10.seconds)
+    }
+
+    /*
+     * An initial set of nodes joins the cluster and crashes, thus leaving the corresponding seed entries at
+     * the backend. A second set of nodes attempts to join the cluster prior to the expiration of the previous
+     * seed entries, thus initiating join attempts to seed nodes that are no longer alive. These attempts will
+     * continue to fail, until the original seed entries expire, and one of the new nodes manages to register
+     * itself as the new seed and formulate a cluster. After that the rest of the nodes will eventually join
+     * as well.
+     */
+    "eventually join the cluster if initial seeds crash" in {
+      val clusterName = generateClusterName()
+      val basePort    = 15005
+      clusterNodes = 0.until(1).map(i => createClusterNode(clusterName, basePort + i))
+      eventuallyUp(clusterNodes, 10.seconds)
+      dispose(clusterNodes)
+      clusterNodes = 1.until(5).map(i => createClusterNode(clusterName, basePort + i))
+
+      Thread.sleep(20.seconds.toMillis)
+
+      for (clusterNode <- clusterNodes) {
+        val clusterExtension = Cluster(clusterNode)
+        assert(clusterExtension.selfMember.status != MemberStatus.Up,
+               s"node ${clusterExtension.selfAddress} is up")
+      }
+
+      eventuallyUp(clusterNodes, 40.seconds)
+    }
+
+    /*
+     * An initial set of nodes joins the cluster and crashes, thus leaving the corresponding seed entries at
+     * the backend. A second set of nodes attempts to join the cluster prior to the expiration of the previous
+     * seed entries, thus initiating join attempts to seed nodes that are no longer alive. These attempts will
+     * continue to fail for a while, until the original set of nodes is restarted, and successfully formulates
+     * a cluster. After that the rest of the nodes will eventually join as well.
+     */
+    "correctly join initial seeds if they crash but recover in time" in {
+      val clusterName = generateClusterName()
+      val basePort    = 15010
+      clusterNodes = 0.until(1).map(i => createClusterNode(clusterName, basePort + i))
+      eventuallyUp(clusterNodes, 10.seconds)
+      dispose(clusterNodes)
+      clusterNodes = 1.until(5).map(i => createClusterNode(clusterName, basePort + i))
+
+      Thread.sleep(10.seconds.toMillis)
+
+      for (clusterNode <- clusterNodes) {
+        val clusterExtension = Cluster(clusterNode)
+        assert(clusterExtension.selfMember.status != MemberStatus.Up,
+               s"node ${clusterExtension.selfAddress} is up")
+      }
+
+      clusterNodes = createClusterNode(clusterName, basePort) +: clusterNodes
+      eventuallyUp(clusterNodes, 10.seconds)
+    }
+  }
+
+  private def eventuallyUp(cluster: scala.Seq[ActorSystem], within: FiniteDuration): Unit =
+    eventually(timeout(Span(within.toSeconds, Seconds)), interval(Span(2, Seconds))) {
+      for (clusterNode <- cluster) {
+        val clusterExtension = Cluster(clusterNode)
+        assert(clusterExtension.selfMember.status == MemberStatus.Up,
+               s"node ${clusterExtension.selfAddress} is not up")
+        assert(clusterExtension.state.members.size == cluster.size)
+      }
+    }
+}
+
+object ConstructrExtensionSpec {
+
+  val ClusterNameBase: String = "ConstructrExtensionSpecCluster"
+
+  def generateClusterName(): String = s"$ClusterNameBase-${UUID.randomUUID()}"
+
+  def createClusterNode(name: String, port: Int): ActorSystem = {
+    val config = ConfigFactory.parseString(s"""
+        | akka {
+        |   actor.provider = akka.cluster.ClusterActorRefProvider
+        |   cluster.jmx.multi-mbeans-in-same-jvm = on
+        |
+        |   remote {
+        |     netty.tcp {
+        |       hostname = "127.0.0.1"
+        |       port = $port
+        |     }
+        |   }
+        | }
+        |
+        | constructr {
+        |   coordination {
+        |     host = "${CoordinationInfo.host}"
+        |     port = ${CoordinationInfo.port}
+        |   }
+        |
+        |   coordination-timeout = 2 seconds
+        |   join-timeout = 3 seconds
+        |   abort-on-join-timeout = false
+        |   nr-of-retries = 1
+        |   retry-delay = 2 seconds
+        |   refresh-interval = 6 seconds
+        | }
+      """.stripMargin)
+    val system = ActorSystem(name, config)
+    ConstructrExtension(system)
+    system
+  }
+
+  def dispose(clusterNodes: scala.Seq[ActorSystem]): Unit =
+    if (clusterNodes.nonEmpty) {
+      implicit val executor = ExecutionContext.Implicits.global
+      Await.result(Future.traverse(clusterNodes)(_.terminate()), 20.seconds)
+    }
+}

--- a/core/src/test/scala/de/heikoseeberger/constructr/testutil/CoordinationInfo.scala
+++ b/core/src/test/scala/de/heikoseeberger/constructr/testutil/CoordinationInfo.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.constructr.testutil
+
+object CoordinationInfo {
+
+  def host: String = {
+    val dockerHostPattern = """tcp://(\S+):\d{1,5}""".r
+    sys.env
+      .get("DOCKER_HOST")
+      .collect({ case dockerHostPattern(address) => address })
+      .getOrElse("127.0.0.1")
+  }
+
+  def port: Int = 2379
+
+}


### PR DESCRIPTION
As discussed in #168, I have implemented the ability to recover from join-timeouts and re-initiate the whole process from scratch. This behavior is configuration driven (see `abort-on-join-timeout`), and enabled by default. Users who want the previous behavior (i.e. failure of the FSM actor) need to set the `abort-on-join-timeout` to true. 

The original issue occurred when new nodes that tried to join the cluster started the process of joining while all of the registered seed nodes where down; i.e. the `GettingNodes` state returned a list of seed nodes that where not online at that moment. This led to a `join-timeout` which in turn led to an FSM failure.

The proposed solution is quite straight-forward: if a `join-timeout` occurs, go back to the `GettingNodes` state. Doing so creates a loop that will end in either of the two following cases:
* The seed nodes registered at the coordinator get back online before their entries expire
* The seed node entries expire, thus `GettingNodes` eventually returns an empty list (which triggers a "happy path" execution for the new-coming nodes)

For the first case to work correctly, the FSM was enhanced with the logic that if the cluster member is notified that it joined the cluster (`MemberJoined`, `MemberUp`) while being in any of the pre-joining states (`BeforeGettingNodes`, `GettingNodes`, `Locking`), then it will immediately transition to the `AddingSelf` state. This was required to be done because executing `joinSeedNodes` after already having joined the cluster has *NO effect* (akka will ignore the command and log a warning message), which means that the FSM would be stuck in the `Joining` state waiting for the cluster event that was received prior to that state (until the state timed out, thus triggering an endless loop).

This implementation also gave me the opportunity to actually implement the `BeforeGettingNodes` - which is depicted in the README file - in order to introduce some latency between the `Locking` and `GettingNodes` states, in the cases when a lock request is rejected (returns false). This was particularly useful in order to reduce the number of lock requests and lock acquirement rejection log messages that occurred in a handful of cases (applied in the scope of #168 as well).

I have added a couple of single-jvm integration tests that demonstrate the scenarios this fix applies to.